### PR TITLE
Refactored relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ Validator for language codes.
 
 ## Relations
 
-Support for PID relations that remove the "metadata" element when they are referenced. So for example:
+Replacement of Invenio relations. Fixes the following issues:
+
+1. Invenio relations can occur only on specific paths and for each pattern, different class must be used
+   (Relation, ListRelation, NestedListRelation)
+2. PID Cache is isolated per request, not set directly on field
+3. Allows to map keys - A key from related object can be renamed/remapped to a different key/path
+4. Provides classes to reference parts of the same record
 
 ```yaml
 # article, id 12
@@ -29,7 +35,7 @@ metadata:
     title: blah
 ```
 
-with this class a referencing dataset would like:
+with mapping referenced article would look like (mapping: `{key: 'metadata.title', target: 'title'}`):
 
 ```yaml
 # dataset:

--- a/format.sh
+++ b/format.sh
@@ -1,0 +1,3 @@
+black oarepo_runtime tests --target-version py310
+autoflake --in-place --remove-all-unused-imports --recursive oarepo_runtime tests
+isort oarepo_runtime tests  --profile black

--- a/oarepo_runtime/cf/__init__.py
+++ b/oarepo_runtime/cf/__init__.py
@@ -1,6 +1,5 @@
-from invenio_records.systemfields import SystemField, DictField
-import marshmallow as ma
 from flask import current_app
+from invenio_records.systemfields import DictField, SystemField
 
 
 class CustomFieldsMixin:

--- a/oarepo_runtime/cf/cli.py
+++ b/oarepo_runtime/cf/cli.py
@@ -2,6 +2,7 @@ import click
 from flask.cli import with_appcontext
 
 from oarepo_runtime.cli import oarepo
+
 from .mappings import prepare_cf_indices
 
 

--- a/oarepo_runtime/cf/mappings.py
+++ b/oarepo_runtime/cf/mappings.py
@@ -1,21 +1,21 @@
 import inspect
+from typing import Iterable, List
+
+import click
+from flask import current_app
+from invenio_records_resources.proxies import current_service_registry
+from invenio_records_resources.services.custom_fields import BaseCF
 from invenio_records_resources.services.custom_fields.mappings import (
     Mapping as InvenioMapping,
 )
-
-from typing import Iterable, List
-import click
-from invenio_records_resources.proxies import current_service_registry
-from invenio_records_resources.services.records.config import RecordServiceConfig
-from invenio_records_resources.services.records.service import RecordService
-from invenio_records_resources.services.custom_fields import BaseCF
 from invenio_records_resources.services.custom_fields.validate import (
     validate_custom_fields,
 )
-from flask import current_app
+from invenio_records_resources.services.records.config import RecordServiceConfig
+from invenio_records_resources.services.records.service import RecordService
+from invenio_search import current_search_client
 from invenio_search.engine import dsl, search
 from invenio_search.utils import build_alias_name
-from invenio_search import current_search_client
 
 from oarepo_runtime.cf import CustomFieldsMixin
 

--- a/oarepo_runtime/config/permissions_presets.py
+++ b/oarepo_runtime/config/permissions_presets.py
@@ -1,5 +1,5 @@
 from invenio_records_permissions import RecordPermissionPolicy
-from invenio_records_permissions.generators import SystemProcess, AnyUser
+from invenio_records_permissions.generators import AnyUser, SystemProcess
 from invenio_records_resources.services.files.generators import AnyUserIfFileIsLocal
 
 
@@ -21,6 +21,7 @@ class ReadOnlyPermissionPolicy(RecordPermissionPolicy):
     can_update_files = [SystemProcess()]
     can_delete_files = [SystemProcess()]
 
+
 class EveryonePermissionPolicy(RecordPermissionPolicy):
     """record policy for read only repository"""
 
@@ -38,4 +39,3 @@ class EveryonePermissionPolicy(RecordPermissionPolicy):
     can_read_files = [SystemProcess(), AnyUser()]
     can_update_files = [SystemProcess(), AnyUser()]
     can_delete_files = [SystemProcess(), AnyUser()]
-

--- a/oarepo_runtime/config/service.py
+++ b/oarepo_runtime/config/service.py
@@ -1,8 +1,11 @@
 from flask import current_app
 
+
 class PermissionsPresetsConfigMixin:
     @property
     def permission_policy_cls(self):
         assert len(self.PERMISSIONS_PRESETS) == 1
-        cls_name = current_app.config["OAREPO_PERMISSIONS_PRESETS"][self.PERMISSIONS_PRESETS[0]]
+        cls_name = current_app.config["OAREPO_PERMISSIONS_PRESETS"][
+            self.PERMISSIONS_PRESETS[0]
+        ]
         return cls_name

--- a/oarepo_runtime/expansions/expandable_fields.py
+++ b/oarepo_runtime/expansions/expandable_fields.py
@@ -3,8 +3,7 @@ from invenio_records_resources.services.records.results import ExpandableField
 
 
 class ReferencedRecordExpandableField(ExpandableField):
-
-    def __init__(self, field_name, keys, service, pid_field='id'):
+    def __init__(self, field_name, keys, service, pid_field="id"):
         super().__init__(field_name)
         self.keys = keys
         self.pid_field = pid_field
@@ -16,7 +15,6 @@ class ReferencedRecordExpandableField(ExpandableField):
         return dict_lookup(value, self.pid_field), self.service
 
     def pick(self, identity, resolved_rec):
-
         ret = {}
         for key in self.keys:
             dict_set(ret, key, dict_lookup(resolved_rec, key))

--- a/oarepo_runtime/ext.py
+++ b/oarepo_runtime/ext.py
@@ -14,8 +14,11 @@ class OARepoRuntime(object):
     def init_config(self, app):
         """Initialize configuration."""
         from . import ext_config
+
         if "OAREPO_PERMISSIONS_PRESETS" not in app.config:
             app.config["OAREPO_PERMISSIONS_PRESETS"] = {}
         for k in ext_config.OAREPO_PERMISSIONS_PRESETS:
             if k not in app.config["OAREPO_PERMISSIONS_PRESETS"]:
-                app.config["OAREPO_PERMISSIONS_PRESETS"][k] = ext_config.OAREPO_PERMISSIONS_PRESETS[k]
+                app.config["OAREPO_PERMISSIONS_PRESETS"][
+                    k
+                ] = ext_config.OAREPO_PERMISSIONS_PRESETS[k]

--- a/oarepo_runtime/ext_config.py
+++ b/oarepo_runtime/ext_config.py
@@ -1,4 +1,7 @@
-from oarepo_runtime.config.permissions_presets import ReadOnlyPermissionPolicy, EveryonePermissionPolicy
+from oarepo_runtime.config.permissions_presets import (
+    EveryonePermissionPolicy,
+    ReadOnlyPermissionPolicy,
+)
 
 OAREPO_PERMISSIONS_PRESETS = {
     "read_only": ReadOnlyPermissionPolicy,

--- a/oarepo_runtime/facets/nested_facet.py
+++ b/oarepo_runtime/facets/nested_facet.py
@@ -1,14 +1,18 @@
 from invenio_search.engine import dsl
 
+
 class NestedLabeledFacet(dsl.Facet):
     agg_type = "nested"
 
-    def __init__(self, path, nested_facet, label = ''):
+    def __init__(self, path, nested_facet, label=""):
         self._path = path
         self._inner = nested_facet
         self._label = label
         super(NestedLabeledFacet, self).__init__(
-            path=path,  aggs={"inner": nested_facet.get_aggregation(),}
+            path=path,
+            aggs={
+                "inner": nested_facet.get_aggregation(),
+            },
         )
 
     def get_values(self, data, filter_values):
@@ -22,7 +26,7 @@ class NestedLabeledFacet(dsl.Facet):
     def get_labelled_values(self, data, filter_values):
         """Get a labelled version of a bucket."""
         try:
-            out = data['buckets']
+            out = data["buckets"]
         except:
             out = []
-        return {'buckets': out, 'label': str(self._label)}
+        return {"buckets": out, "label": str(self._label)}

--- a/oarepo_runtime/relations/__init__.py
+++ b/oarepo_runtime/relations/__init__.py
@@ -1,143 +1,19 @@
-from invenio_records_resources.records.systemfields.relations import (
-    PIDRelation,
-    PIDListRelation,
-    PIDNestedListRelation,
-)
-from invenio_records.dictutils import dict_lookup, dict_set
-
-from invenio_records.systemfields.relations import (
+from .base import (
+    InvalidCheckValue,
+    InvalidRelationValue,
+    Relation,
     RelationResult,
-    RelationListResult,
-    RelationNestedListResult,
-    RelationBase,
-    ListRelation,
-    NestedListRelation,
+    RelationsField,
 )
+from .internal import InternalRelation
+from .pid_relation import PIDRelation
 
-
-class MetadataRelationResultMixin:
-    def _dereference_one(self, data, keys, attrs):
-        ret = super()._dereference_one(data, keys, attrs)
-        if "metadata" in ret:
-            ret.update(ret.pop("metadata"))
-        return ret
-
-
-class MetadataRelationResult(MetadataRelationResultMixin, RelationResult):
-    pass
-
-
-class MetadataRelationListResult(MetadataRelationResultMixin, RelationListResult):
-    pass
-
-
-class MetadataRelationNestedListResult(
-    MetadataRelationResultMixin, RelationNestedListResult
-):
-    pass
-
-
-class MetadataPIDRelation(PIDRelation):
-    result_cls = MetadataRelationResult
-
-
-class MetadataPIDListRelation(PIDListRelation):
-    result_cls = MetadataRelationListResult
-
-
-class MetadataPIDNestedListRelation(PIDNestedListRelation):
-    result_cls = MetadataRelationNestedListResult
-
-
-from invenio_records.dictutils import dict_lookup, dict_set
-
-
-class InternalResultMixin:
-    def _lookup_id(self):
-        return (super()._lookup_id(), self.record)
-
-    def _dereference_one(self, data, keys, attrs):
-        """Dereference a single object into a dict."""
-
-        # Get related record
-        obj = self.resolve((data[self.field._value_key_suffix], self.record))
-        # Inject selected key/values from related record into
-        # the current record.
-
-        # From record dictionary
-        if keys is None:
-            data.update({k: v for k, v in obj.items()})
-        else:
-            new_obj = {}
-            for k in keys:
-                try:
-                    val = dict_lookup(obj, k)
-                    if val:
-                        dict_set(new_obj, k, val)
-                except KeyError:
-                    pass
-            data.update(new_obj)
-
-        # From record attributes (i.e. system fields)
-        for a in attrs:
-            data[a] = getattr(obj, a)
-
-        return data
-
-
-class InternalResult(InternalResultMixin, RelationResult):
-    pass
-
-
-class InternalRelation(RelationBase):
-    result_cls = InternalResult
-
-    def __init__(self, *args, pid_field=None, **kwargs):
-        """Initialize the PK relation."""
-        self.pid_field = pid_field
-        super().__init__(*args, **kwargs)
-
-    def resolve(self, id_):
-        pid_field = self.pid_field
-        if not id_:
-            return None
-
-        if not pid_field:
-            return id_[1]
-
-        field_or_array = dict_lookup(id_[1], pid_field)
-        if not field_or_array:
-            return None
-
-        if isinstance(field_or_array, dict):
-            field_or_array = [field_or_array]
-        if not isinstance(field_or_array, list):
-            raise KeyError(
-                f"PID field {pid_field} does not point to an object or array of objects"
-            )
-        for f in field_or_array:
-            if not isinstance(f, dict):
-                raise KeyError(
-                    f"PID field {pid_field} does not point to an array of objects - array member is {type(f)}: {f}"
-                )
-            if id_[0] == f.get("id", None):
-                return f
-        return None
-
-
-class InternalListResult(InternalResultMixin, RelationListResult):
-    def _lookup_id(self, data):
-        return (dict_lookup(data, self.field._value_key_suffix), self.record)
-
-
-class InternalListRelation(ListRelation, InternalRelation):
-    result_cls = InternalListResult
-
-
-class InternalNestedListResult(InternalResultMixin, RelationNestedListResult):
-    def _lookup_id(self, data):
-        return (dict_lookup(data, self.field._value_key_suffix), self.record)
-
-
-class InternalNestedListRelation(NestedListRelation, InternalRelation):
-    result_cls = InternalNestedListResult
+__all__ = (
+    "Relation",
+    "RelationResult",
+    "InvalidRelationValue",
+    "InvalidCheckValue",
+    "RelationsField",
+    "InternalRelation",
+    "PIDRelation",
+)

--- a/oarepo_runtime/relations/base.py
+++ b/oarepo_runtime/relations/base.py
@@ -1,0 +1,242 @@
+from functools import cached_property
+from typing import List
+
+from invenio_records.dictutils import dict_lookup, dict_set
+from invenio_records.systemfields.base import SystemField
+from invenio_records.systemfields.relations import (
+    InvalidCheckValue,
+    InvalidRelationValue,
+)
+
+from .lookup import LookupResult, lookup_key
+from .mapping import RelationsMapping
+
+
+class RelationResult:
+    def __init__(self, field, record, cache) -> None:
+        self.field = field
+        self.record = record
+        self.cache = cache
+
+    def validate(self):
+        found: List[LookupResult] = lookup_key(self.record, self.field.key)
+        for relation in found:
+            if not isinstance(relation.value, dict):
+                raise InvalidRelationValue(
+                    f"Value at path {relation.path} must be dict, found {relation.value}"
+                )
+
+            relation_id = self._lookup_id(relation)
+
+            data = self.resolve(relation_id)
+            if not data:
+                raise InvalidRelationValue(f"Invalid value {relation_id}.")
+
+            if self.field.value_check:
+                self._value_check(relation.value, data)
+
+    def clean(self, keys=None, attrs=None):
+        """Clean the dereferenced attributes inside the record."""
+        found: List[LookupResult] = lookup_key(self.record, self.field.key)
+        for relation in found:
+            self._clean_one(
+                relation, keys or self.field.keys, attrs or self.field.attrs
+            )
+
+    def dereference(self, keys=None, attrs=None):
+        """Dereference the relation field object inside the record."""
+        found: List[LookupResult] = lookup_key(self.record, self.field.key)
+        for relation in found:
+            self._dereference_one(
+                relation, keys or self.field.keys, attrs or self.field.attrs
+            )
+
+    def _clean_one(self, relation: LookupResult, keys, attrs):
+        """Remove all but "id" key for a dereferenced related object."""
+        relation_id = self._lookup_id(relation)
+        relation.value.clear()
+        self._store_id(relation, relation_id)
+        return relation
+
+    def _needs_update_relation_value(self, _relation: LookupResult):
+        """
+        Returns True if the relation needs resolving and updating value
+
+        :param relation: relation being processed
+        """
+        return True
+
+    def _add_version_info(self, data, relation: LookupResult, resolved_object):
+        """
+        Adds versioning info on relation data
+
+        :param data: relation data
+        :param relation: relation being processed
+        :param resolved_object: the object to which this relation points to
+        """
+
+    def _dereference_one(self, relation: LookupResult, keys, attrs):
+        """Dereference a single object into a dict."""
+        data = relation.value
+        if not self._needs_update_relation_value(relation):
+            return
+
+        data = relation.value
+        # Get related record
+        obj = self.resolve(self._lookup_id(relation))
+        # Inject selected key/values from related record into
+        # the current record.
+
+        # From record dictionary
+        if keys is None:
+            data.update({k: v for k, v in obj.items()})
+        else:
+            new_obj = {}
+            for k in keys:
+                try:
+                    val = dict_lookup(obj, k)
+                    if val:
+                        dict_set(new_obj, k, val)
+                except KeyError:
+                    pass
+            data.update(new_obj)
+
+        # From record attributes (i.e. system fields)
+        for a in attrs:
+            data[a] = getattr(obj, a)
+
+        self._add_version_info(data, relation, obj)
+        return data
+
+    def _value_check(self, value_to_check, object):
+        """Checks if the value is present in the object."""
+        for key, value in value_to_check.items():
+            if key not in object:
+                raise InvalidCheckValue(f"Invalid key {key}.")
+            if isinstance(value, dict):
+                self._value_check(value, object[key])
+            else:
+                if not isinstance(value, list):
+                    raise InvalidCheckValue(
+                        f"Invalid value_check value: {value}; it must be " "a list"
+                    )
+                elif isinstance(object[key], list):
+                    value_exist = set(object[key]).intersection(set(value))
+                    if not value_exist:
+                        raise InvalidCheckValue(
+                            f"Failed cross checking value_check value "
+                            f"{value} with record value {object[key]}."
+                        )
+                else:
+                    if object[key] not in value:
+                        raise InvalidCheckValue(
+                            f"Failed cross checking value_check value "
+                            f"{value} with record value {object[key]}."
+                        )
+
+    def _lookup_id(self, relation: LookupResult):
+        relation_id = relation.value.get("id", None)
+        if not relation_id:
+            raise InvalidRelationValue(
+                f"Value at path {relation.path} must contain non-empty 'id' field, found {relation.value}"
+            )
+        return relation_id
+
+    def _store_id(self, relation: LookupResult, relation_id):
+        relation.value["id"] = relation_id
+
+    def resolve(self, id_):
+        raise NotImplementedError("Please implement this method in your subclass")
+
+
+class Relation:
+    result_cls = RelationResult
+
+    def __init__(
+        self,
+        key=None,
+        attrs=None,
+        keys=None,
+        _clear_empty=True,
+        value_check=None,
+    ):
+        """Initialize the relation."""
+        self.key = key
+        self.attrs = attrs or []
+        self.keys = keys or []
+        self._clear_empty = _clear_empty
+        self.value_check = value_check
+
+    def get_value(self, record, cache):
+        """Return the resolved relation from a record."""
+        return self.result_cls(self, record, cache)
+
+
+class RelationsField(SystemField):
+    # taken from RelationsField
+    def __init__(self, **fields):
+        """Initialize the field."""
+        super().__init__()
+        assert all(isinstance(f, Relation) for f in fields.values())
+        self._original_fields = fields
+
+    def __getattr__(self, name):
+        """Get a field definition."""
+        if name in self._fields:
+            return self._fields[name]
+        raise AttributeError
+
+    def __iter__(self):
+        """Iterate over the configured fields."""
+        return iter(getattr(self, f) for f in self._fields)
+
+    def __contains__(self, name):
+        """Return if a field exists in the configured fields."""
+        return name in self._fields
+
+    #
+    # Properties
+    #
+    @cached_property
+    def _fields(self):
+        """Get the fields."""
+        return self._original_fields
+
+    #
+    # Helpers
+    #
+    def obj(self, instance):
+        """Get the relations object."""
+        # Check cache
+        obj = self._get_cache(instance)
+        if obj:
+            return obj
+        obj = RelationsMapping(record=instance, fields=self._fields)
+        self._set_cache(instance, obj)
+        return obj
+
+    #
+    # Data descriptor
+    #
+    def __get__(self, record, owner=None):
+        """Accessing the attribute."""
+        # Class access
+        if record is None:
+            return self
+        return self.obj(record)
+
+    def __set__(self, instance, values):
+        """Setting the attribute."""
+        obj = self.obj(instance)
+        for k, v in values.items():
+            setattr(obj, k, v)
+
+    #
+    # Record extension
+    #
+    def pre_commit(self, record):
+        """Initialise the model field."""
+        obj = self.obj(record)
+        obj.validate()
+        obj.clean()
+        obj.dereference()

--- a/oarepo_runtime/relations/internal.py
+++ b/oarepo_runtime/relations/internal.py
@@ -1,0 +1,46 @@
+from invenio_records.systemfields.relations import InvalidRelationValue
+
+from .base import Relation, RelationResult
+from .lookup import LookupResult, lookup_key
+
+
+class InternalResult(RelationResult):
+    def resolve(self, id_):
+        related_part = self.field.related_part
+
+        if not related_part:
+            return self.record
+
+        potential_values = list(lookup_key(self.record, related_part))
+
+        if not id_:
+            if len(potential_values) > 1:
+                raise InvalidRelationValue(
+                    "Relation returned more than one part at "
+                    f"{related_part} but has no id to check those parts against"
+                )
+            return potential_values[0].value
+
+        for rel in potential_values:
+            if not isinstance(rel.value, dict):
+                raise KeyError(
+                    f"Related part {related_part} does not point to an array of objects at path "
+                    f"{rel.path}- array member is {type(rel.value)}: {rel.value}"
+                )
+
+            if id_ == rel.value.get("id", None):
+                return rel.value
+
+        raise KeyError(f"No data for relation at path {related_part} with id {id_}")
+
+    def _lookup_id(self, relation: LookupResult):
+        relation_id = relation.value.get("id", None)
+        return relation_id
+
+
+class InternalRelation(Relation):
+    result_cls = InternalResult
+
+    def __init__(self, key=None, related_part=None, **kwargs):
+        super().__init__(key=key, **kwargs)
+        self.related_part = related_part

--- a/oarepo_runtime/relations/lookup.py
+++ b/oarepo_runtime/relations/lookup.py
@@ -1,0 +1,28 @@
+import dataclasses
+from typing import Any, Tuple
+
+
+@dataclasses.dataclass
+class LookupResult:
+    path: Tuple[str]
+    value: Any
+
+
+def lookup_key(record, key):
+    """more generic version of dict_lookup, for arrays does not look up by index but returns all members of array"""
+
+    def _internal_lookup_key(key, data, path: Tuple):
+        if isinstance(data, (tuple, list)):
+            for idx, d in enumerate(data):
+                yield from _internal_lookup_key(key, d, path + (idx,))
+            return
+        if not key:
+            yield LookupResult(path, data)
+            return
+        if not isinstance(data, dict):
+            return
+        if key[0] in data:
+            yield from _internal_lookup_key(key[1:], data[key[0]], path + (key[0],))
+
+    key = key.split(".")
+    return list(_internal_lookup_key(key, record, tuple()))

--- a/oarepo_runtime/relations/mapping.py
+++ b/oarepo_runtime/relations/mapping.py
@@ -1,0 +1,30 @@
+class RelationsMapping:
+    """Helper class for managing relation fields."""
+
+    def __init__(self, record, fields):
+        """Initialize the relations mapping."""
+        # Needed because we overwrite __setattr__
+        cache = {}
+        self._fields = fields
+        for name, fld in fields.items():
+            field_value = fld.get_value(record, cache)
+            setattr(self, name, field_value)
+
+    def __iter__(self):
+        """Iterate over the relations fields."""
+        return iter(self._fields)
+
+    def validate(self, fields=None):
+        """Validates all relations in the record."""
+        for name in fields or self:
+            getattr(self, name).validate()
+
+    def dereference(self, fields=None):
+        """Dereferences relation fields."""
+        for name in fields or self:
+            getattr(self, name).dereference()
+
+    def clean(self, fields=None):
+        """Clean dereferenced relation fields."""
+        for name in fields or self:
+            getattr(self, name).clean()

--- a/oarepo_runtime/relations/pid_relation.py
+++ b/oarepo_runtime/relations/pid_relation.py
@@ -1,0 +1,58 @@
+from .base import Relation, RelationResult
+from .lookup import LookupResult
+
+
+class PIDRelationResult(RelationResult):
+    def resolve(self, id_):
+        """Resolve the value using the record class."""
+        # TODO: handle permissions here !!!!!!
+        pid_field = self.field.pid_field.field
+        cache_key = (
+            pid_field._provider.pid_type
+            if pid_field._provider
+            else pid_field._pid_type,
+            id_,
+        )
+        if cache_key in self.cache:
+            obj = self.cache[cache_key]
+            return obj
+
+        try:
+            obj = self.field.pid_field.resolve(id_)
+            # We detach the related record model from the database session when
+            # we add it in the cache. Otherwise, accessing the cached record
+            # model, will execute a new select query after a db.session.commit.
+            db.session.expunge(obj.model)
+            self.cache[cache_key] = obj
+            return obj
+        except Exception as e:
+            raise KeyError(
+                f"Repository object {cache_key} has not been found or there was an exception accessing it"
+            ) from e
+
+    def _needs_update_relation_value(self, relation: LookupResult):
+        # Don't dereference if already referenced.
+        return "@v" not in relation.value
+
+    def _add_version_info(self, data, relation: LookupResult, resolved_object):
+        data["@v"] = f"{resolved_object.id}::{resolved_object.revision_id}"
+
+
+class PIDRelation(Relation):
+    result_cls = PIDRelationResult
+
+    def __init__(self, key=None, pid_field=None, **kwargs):
+        super().__init__(key=key, **kwargs)
+        self.pid_field = pid_field
+
+
+class MetadataRelationResult(PIDRelationResult):
+    def _dereference_one(self, relation: LookupResult, keys, attrs):
+        ret = super()._dereference_one(relation, keys, attrs)
+        if "metadata" in ret:
+            ret.update(ret.pop("metadata"))
+        return ret
+
+
+class MetadataPIDRelation(PIDRelation):
+    result_cls = MetadataRelationResult

--- a/oarepo_runtime/relations/pid_relation.py
+++ b/oarepo_runtime/relations/pid_relation.py
@@ -1,3 +1,5 @@
+from invenio_db import db
+
 from .base import Relation, RelationResult
 from .lookup import LookupResult
 

--- a/oarepo_runtime/validation/dates.py
+++ b/oarepo_runtime/validation/dates.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+
 from marshmallow.exceptions import ValidationError
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-runtime
-version = 1.0.9
+version = 1.0.10
 description = A set of runtime extensions of Invenio repository
 authors = Alzbeta
 readme = README.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,9 @@ install_requires =
 [options.extras_require]
 devs =
     pytest>=7.1.2
+    black
+    isort
+    autoflake
 tests =
     pytest>=7.1.2
 

--- a/tests/test_lang_codes.py
+++ b/tests/test_lang_codes.py
@@ -1,6 +1,7 @@
-from oarepo_runtime.i18n.validation import lang_code_validator
 import pytest
 from marshmallow.exceptions import ValidationError
+
+from oarepo_runtime.i18n.validation import lang_code_validator
 
 
 def test_lang_code():

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,5 +1,6 @@
 import pytest
 from marshmallow.exceptions import ValidationError
+
 from oarepo_runtime.validation.dates import validate_date
 
 


### PR DESCRIPTION
OARepo relations now do not use Invenio base classes as we need to address a wider set of use cases. 
However, our relations have similar API to the old ones
