### PR TITLE
Fixing double creation bug in datastreams

### DIFF
--- a/oarepo_runtime/datastreams/writers/service.py
+++ b/oarepo_runtime/datastreams/writers/service.py
@@ -72,10 +72,15 @@ class ServiceWriter(BaseWriter):
 
         entry_id = self._get_stream_entry_id(stream_entry)
 
-        if entry_id and self._update:
-            repository_entry = self.try_update(entry_id, entry, **service_kwargs)
-            if repository_entry:
-                do_create = False
+        if entry_id:
+            if self._update:
+                repository_entry = self.try_update(entry_id, entry, **service_kwargs)
+                if repository_entry:
+                    do_create = False
+            else:
+                current = self._resolve(entry_id)
+                if current:
+                    do_create = False
 
         if do_create:
             repository_entry = self._service.create(

--- a/oarepo_runtime/datastreams/writers/service.py
+++ b/oarepo_runtime/datastreams/writers/service.py
@@ -87,10 +87,11 @@ class ServiceWriter(BaseWriter):
                 self._identity, entry, **service_kwargs
             )
 
-        stream_entry.entry = repository_entry.data
-        stream_entry.id = repository_entry.id
+        if repository_entry:
+            stream_entry.entry = repository_entry.data
+            stream_entry.id = repository_entry.id
 
-        stream_entry.context["revision_id"] = repository_entry._record.revision_id
+            stream_entry.context["revision_id"] = repository_entry._record.revision_id
 
     def try_update(self, entry_id, entry, **service_kwargs):
         current = self._resolve(entry_id)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-runtime
-version = 1.4.45
+version = 1.4.46
 description = A set of runtime extensions of Invenio repository
 authors = Alzbeta Pokorna
 readme = README.md


### PR DESCRIPTION
When update is not allowed in datastream service's configuration and there is an id on a record, the record is created again regardless if it already exists or not. This could lead to duplicated records.