### PR TITLE
Facet filtering behaviour change for the system identity

### DIFF
--- a/oarepo_runtime/services/facets/params.py
+++ b/oarepo_runtime/services/facets/params.py
@@ -3,7 +3,7 @@ import logging
 from typing import List
 
 from flask import current_app
-from flask_principal import Identity, RoleNeed
+from flask_principal import Identity, Need
 from invenio_access.permissions import system_user_id
 from invenio_app.helpers import obj_or_import_string
 from invenio_records_resources.services.records.facets import FacetsResponse
@@ -63,9 +63,7 @@ class GroupedFacetsParam(FacetsParam):
 
         has_system_user_id = identity.id == system_user_id
         has_system_process_need = any(
-            need.value == "system_process"
-            for need in identity.provides
-            if isinstance(need, RoleNeed)
+            need.method == "system_process" for need in identity.provides
         )
         if has_system_user_id or has_system_process_need:
             return self.facets

--- a/oarepo_runtime/services/facets/params.py
+++ b/oarepo_runtime/services/facets/params.py
@@ -3,7 +3,8 @@ import logging
 from typing import List
 
 from flask import current_app
-from flask_principal import Identity
+from flask_principal import Identity, RoleNeed
+from invenio_access.permissions import system_user_id
 from invenio_app.helpers import obj_or_import_string
 from invenio_records_resources.services.records.facets import FacetsResponse
 from invenio_records_resources.services.records.params import FacetsParam
@@ -60,16 +61,16 @@ class GroupedFacetsParam(FacetsParam):
             )
             return self.facets
 
-        user_facets = {}
-        if not self.facet_groups:
-            user_facets.update(self.facets)
-        else:
-            self.facets.clear()  # TODO: why is this needed?
-            user_facets.update(self.facet_groups.get("default", {}))
+        has_system_user_id = identity.id == system_user_id
+        has_system_process_need = any(
+            need.value == "system_process"
+            for need in identity.provides
+            if isinstance(need, RoleNeed)
+        )
+        if has_system_user_id or has_system_process_need:
+            return self.facets
 
-        groups = self.identity_facet_groups(identity)
-        for group in groups:
-            user_facets.update(self.facet_groups.get(group, {}))
+        user_facets = self._filter_user_facets(identity)
         return user_facets
 
     def aggregate(self, search, user_facets):
@@ -97,3 +98,16 @@ class GroupedFacetsParam(FacetsParam):
         params.update(self.selected_values)
 
         return search
+
+    def _filter_user_facets(self, identity: Identity):
+        user_facets = {}
+        if not self.facet_groups:
+            user_facets.update(self.facets)
+        else:
+            self.facets.clear()  # TODO: why is this needed?
+            user_facets.update(self.facet_groups.get("default", {}))
+
+        groups = self.identity_facet_groups(identity)
+        for group in groups:
+            user_facets.update(self.facet_groups.get(group, {}))
+        return user_facets

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-runtime
-version = 1.5.1
+version = 1.5.2
 description = A set of runtime extensions of Invenio repository
 authors = Alzbeta Pokorna
 readme = README.md


### PR DESCRIPTION
- there is an ongoing issue when harvesting records from NUSL via S3 bucket named "nusl-harvest-02"
- we think it is because there is not oai identifier facet present to filter successfully harvested records, which then returns wrong items back - error
- therefore this issue aims to change the facet filtering process to correctly assign oai identifier facet to system identity user

Changes in code:
- extracted method
- added system identity check