### PR TITLE
Trappl/be 537 oarepo runtime

### DIFF
--- a/oarepo_runtime/datastreams/writers/attachments_service.py
+++ b/oarepo_runtime/datastreams/writers/attachments_service.py
@@ -51,7 +51,7 @@ class AttachmentsServiceWriter(BaseWriter):
 
         with BulkUnitOfWork() as uow:
             for entry in batch.entries:
-                if not entry.ok or entry.deleted:
+                if not entry.ok or entry.deleted or not entry.entry["files"]["enabled"]:
                     continue
                 with record_invenio_exceptions(entry):
                     self._write_attachments(entry, uow)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-runtime
-version = 1.5.68
+version = 1.5.69
 description = A set of runtime extensions of Invenio repository
 authors = Alzbeta Pokorna
 readme = README.md


### PR DESCRIPTION
- skip entries without files in the attachment writer