### PR TITLE
Arseniipogodin/be 680 invenio oarepo configuration tmpblah

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-runtime
-version = 1.5.98
+version = 1.5.99
 description = A set of runtime extensions of Invenio repository
 authors = Alzbeta Pokorna
 readme = README.md


### PR DESCRIPTION
Linear be 680 invenio oarepo configuration tmpblah fix that causes "invenio oarepo configuration -" to fail due to "OAUTH_REMOTE_APPS = {"orcid": orcid.REMOTE_AP}"