### PR TITLE
Exports to response handlers

### DIFF
--- a/oarepo_runtime/resources/__init__.py
+++ b/oarepo_runtime/resources/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2025 CESNET z.s.p.o.
+#
+# This file is a part of oarepo-runtime (see http://github.com/oarepo/oarepo-runtime).
+#
+# oarepo-runtime is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+
+"""Extensions for RDM API resources."""
+
+from __future__ import annotations
+
+from .config import exports_to_response_handlers
+
+__all__ = ("exports_to_response_handlers",)

--- a/oarepo_runtime/resources/config.py
+++ b/oarepo_runtime/resources/config.py
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2025 CESNET z.s.p.o.
+#
+# This file is a part of oarepo-runtime (see http://github.com/oarepo/oarepo-runtime).
+#
+# oarepo-runtime is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+
+"""Extensions for RDM API resources."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from flask_resources.responses import ResponseHandler
+from invenio_records_resources.resources.records.headers import etag_headers
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from oarepo_runtime.api import Export
+
+
+def exports_to_response_handlers(
+    exports: Iterable[Export],
+) -> dict[str, ResponseHandler]:
+    """Convert exports to a dictionary of mimetype -> response handlers."""
+    return {
+        export.mimetype: ResponseHandler(
+            serializer=export.serializer,
+            headers=etag_headers,
+        )
+        for export in exports
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,14 +10,13 @@
 # https://github.com/inveniosoftware/invenio-records-resources/blob/master/tests/conftest.py
 #
 #
-from __future__ import annotations
-
 """Pytest configuration.
 
 See https://pytest-invenio.readthedocs.io/ for documentation on which test
 fixtures are available.
 """
 
+from __future__ import annotations
 
 import pytest
 from flask_principal import Identity, Need, UserNeed


### PR DESCRIPTION
Added exports_to_response_handlers helper function to convert Export into a response handler. This function will be primarily used in the oarepo-model to perform the conversion.