### PR TITLE
not using external in invenio_url_for

### DIFF
--- a/oarepo_runtime/api.py
+++ b/oarepo_runtime/api.py
@@ -377,10 +377,14 @@ class Model[
 
     def api_url(self, view_name: str, **kwargs: Any) -> str:
         """Get the API URL for the model."""
+        if "_external" in kwargs:
+            raise ValueError("_external should not be passed, invenio_url_for always creates external links")
         return cast("str", invenio_url_for(f"{self.api_blueprint_name}.{view_name}", **kwargs))
 
     def ui_url(self, view_name: str, **kwargs: Any) -> str | None:
         """Get the UI URL for the model."""
+        if "_external" in kwargs:
+            raise ValueError("_external should not be passed, invenio_url_for always creates external links")
         if self.ui_blueprint_name is None:
             return None
         return cast("str", invenio_url_for(f"{self.ui_blueprint_name}.{view_name}", **kwargs))

--- a/oarepo_runtime/info/views.py
+++ b/oarepo_runtime/info/views.py
@@ -189,7 +189,7 @@ class InfoResource(BaseResource):
     def _get_model_api_endpoint(self, model: Model) -> str | None:
         try:
             alias = model.api_blueprint_name
-            return model.api_url("search", type=alias, _external=True)
+            return model.api_url("search", type=alias)
         except BuildError:  # pragma: no cover
             logger.exception("Failed to get model api endpoint")
             return None
@@ -197,7 +197,7 @@ class InfoResource(BaseResource):
     def _get_model_draft_endpoint(self, model: Model) -> str | None:
         try:
             alias = model.api_blueprint_name
-            return model.api_url("search_user_records", type=alias, _external=True)
+            return model.api_url("search_user_records", type=alias)
         except BuildError:
             logger.exception("Failed to get model draft endpoint")
             return None
@@ -304,7 +304,7 @@ class InfoResource(BaseResource):
                 "metadata": False,
             }
 
-        base_url = invenio_url_for("vocabularies.search", type="languages", _external=True)
+        base_url = invenio_url_for("vocabularies.search", type="languages")
         base_url = replace_path_in_url(base_url, "/")
         ret = [
             _generate_rdm_vocabulary(base_url, Affiliation, "affiliations", "Affiliations", "", special=True),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -118,6 +118,16 @@ def test_api_url(app):
     search_url = model.api_url("search", type="languages")
     assert search_url.endswith("/api/vocabularies/languages")
 
+    with pytest.raises(ValueError, match="_external should not be passed"):
+        model.api_url("search", type="languages", _external=True)
+
+
+def test_ui_url_external_raises(app):
+    """Test ui_url raises ValueError when _external is passed."""
+    model = current_runtime.models["vocabularies"]
+    with pytest.raises(ValueError, match="_external should not be passed"):
+        model.ui_url("search", type="languages", _external=True)
+
 
 def test_model_without_ui_blueprint_name(app):
     """Test api_url method."""

--- a/tests/test_info_endpoints.py
+++ b/tests/test_info_endpoints.py
@@ -57,10 +57,10 @@ def test_info_repository_endpoint(client, lang_type, info_blueprint):
     assert mock_model["metadata"]
     assert mock_model["version"] == "1.0.0"
     assert mock_model["links"] == {
-        "deposit": "https://127.0.0.1:5000/api/mocks?type=mocks&_external=True",
+        "deposit": "https://127.0.0.1:5000/api/mocks?type=mocks",
         "drafts": None,
         "html": "https://127.0.0.1:5000/mocks",
-        "records": "https://127.0.0.1:5000/api/mocks?type=mocks&_external=True",
+        "records": "https://127.0.0.1:5000/api/mocks?type=mocks",
     }
 
     model_names = [model_dict["name"] for model_dict in models_info]


### PR DESCRIPTION
invenio_url_for always creates external links and does not take _extgernal kwarg like url_for from flask.
https://github.com/inveniosoftware/invenio-base/blob/f868e5e91cef7a6d4c7edfdb76669443484da331/invenio_base/urls/helpers.py#L35