### PR TITLE
Zerbe/fix signposting missing datacite

### DIFF
--- a/oarepo-runtime-signposting-missing-datacite-issue.md
+++ b/oarepo-runtime-signposting-missing-datacite-issue.md
@@ -1,0 +1,83 @@
+# Bug: `record_dict_to_linkset` crashes with HTTP 500 for record types without a DataCite export
+
+## Summary
+
+`oarepo_ui`'s `response_header_signposting` decorator calls `record_dict_to_linkset`, which calls
+`get_export_from_serialized_record(..., export_mimetype="application/vnd.datacite.datacite+json")`.
+For record types that have no DataCite export configured, `get_export_from_serialized_record` raises
+`ValueError`, which propagates through `record_dict_to_linkset` and causes an HTTP 500 on every
+request to that record's detail page.
+
+The decorator already guards against a falsy linkset result (`if record_linkset:`), so the correct
+silent fallback is to return an empty string (or `{}` for the JSON variant) rather than letting the
+exception propagate.
+
+## Affected version
+
+`oarepo-runtime` 2.0.0dev59
+
+## Steps to reproduce
+
+1. Register a record type (e.g., `research_activity`, `sample`, `tool`) that does **not** declare
+   a DataCite JSON export in its serializers configuration.
+2. Create a record of that type.
+3. Navigate to the record detail page.
+
+**Result:**
+```
+ValueError: No export found for mimetype application/vnd.datacite.datacite+json
+```
+propagated from `oarepo_runtime.ext.OARepoRuntime.get_export_from_serialized_record`
+through `record_dict_to_linkset`, returning HTTP 500.
+
+## Root cause
+
+`record_dict_to_linkset` (and `record_dict_to_json_linkset`) calls
+`current_runtime.get_export_from_serialized_record` without guarding against the documented
+`ValueError` that is raised when the requested export mimetype is not registered for the record
+type. The call is outside the `try/except` block added in the earlier `create_linkset` fix.
+
+```python
+# Before fix — ValueError propagates
+def record_dict_to_linkset(record_dict, include_reverse_relations=True):
+    datacite_dict = current_runtime.get_export_from_serialized_record(
+        record_dict=record_dict,
+        representation=ExportRepresentation.DICTIONARY,
+        export_mimetype="application/vnd.datacite.datacite+json",
+    )
+    return create_linkset(datacite_dict, record_dict, include_reverse_relations)
+```
+
+## Proposed fix
+
+Wrap the `get_export_from_serialized_record` call in both `record_dict_to_linkset` and
+`record_dict_to_json_linkset` with a `try/except (ValueError, KeyError)` that returns the
+appropriate empty value so signposting is silently skipped for unsupported record types.
+
+```python
+# After fix
+def record_dict_to_linkset(record_dict, include_reverse_relations=True):
+    try:
+        datacite_dict = current_runtime.get_export_from_serialized_record(
+            record_dict=record_dict,
+            representation=ExportRepresentation.DICTIONARY,
+            export_mimetype="application/vnd.datacite.datacite+json",
+        )
+    except (ValueError, KeyError):
+        return ""
+    return create_linkset(datacite_dict, record_dict, include_reverse_relations)
+```
+
+The same pattern applies to `record_dict_to_json_linkset`, returning `{}` on error.
+
+## Workaround (applied in frozen_testing)
+
+`patches.py` monkey-patches both `oarepo_runtime.resources.signposting.record_dict_to_linkset`
+and (if already imported) `oarepo_ui.resources.decorators.signposting.record_dict_to_linkset`
+with a safe wrapper that catches `ValueError` and `KeyError`.
+
+## Note on related upstream fix
+
+Commit `cdd4b44` (`fix: return empty linkset during signposting error`) added a `try/except` block
+inside `create_linkset`, but this does not protect against the `ValueError` raised by
+`get_export_from_serialized_record` before `create_linkset` is ever called. Both fixes are needed.

--- a/oarepo_runtime/resources/signposting/__init__.py
+++ b/oarepo_runtime/resources/signposting/__init__.py
@@ -408,11 +408,14 @@ def landing_page_signpost_links_list(datacite_dict: dict, record_dict: dict, sho
 
 def record_dict_to_linkset(record_dict: dict, include_reverse_relations: bool = True) -> str:
     """Create a linkset from the dictionary of a record item. Get datacite to build linkset from model exports."""
-    datacite_dict = current_runtime.get_export_from_serialized_record(
-        record_dict=record_dict,
-        representation=ExportRepresentation.DICTIONARY,
-        export_mimetype="application/vnd.datacite.datacite+json",
-    )
+    try:
+        datacite_dict = current_runtime.get_export_from_serialized_record(
+            record_dict=record_dict,
+            representation=ExportRepresentation.DICTIONARY,
+            export_mimetype="application/vnd.datacite.datacite+json",
+        )
+    except (ValueError, KeyError):
+        return ""
     return create_linkset(datacite_dict, record_dict, include_reverse_relations)
 
 
@@ -420,9 +423,12 @@ def record_dict_to_json_linkset(
     record_dict: dict, include_reverse_relations: bool = True
 ) -> dict[str, list[dict[str, Any]]]:
     """Create a JSON linkset from the dictionary of a record item. Get datacite to build linkset from model exports."""
-    datacite_dict = current_runtime.get_export_from_serialized_record(
-        record_dict=record_dict,
-        representation=ExportRepresentation.DICTIONARY,
-        export_mimetype="application/vnd.datacite.datacite+json",
-    )
+    try:
+        datacite_dict = current_runtime.get_export_from_serialized_record(
+            record_dict=record_dict,
+            representation=ExportRepresentation.DICTIONARY,
+            export_mimetype="application/vnd.datacite.datacite+json",
+        )
+    except (ValueError, KeyError):
+        return {}
     return create_linkset_json(datacite_dict, record_dict, include_reverse_relations)

--- a/tests/test_signposting_missing_datacite.py
+++ b/tests/test_signposting_missing_datacite.py
@@ -1,0 +1,109 @@
+#
+# Copyright (c) 2025 CESNET z.s.p.o.
+#
+# This file is a part of oarepo-runtime (see https://github.com/oarepo/oarepo-runtime).
+#
+# oarepo-runtime is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+"""Unit tests: record_dict_to_linkset/record_dict_to_json_linkset with missing DataCite export."""
+
+from unittest.mock import MagicMock, patch
+
+from oarepo_runtime.resources.signposting import (
+    record_dict_to_json_linkset,
+    record_dict_to_linkset,
+)
+
+
+def _mock_runtime(raise_=None, return_=None):
+    """Return a runtime stub that raises or returns on get_export_from_serialized_record."""
+    m = MagicMock()
+    if raise_ is not None:
+        m.get_export_from_serialized_record.side_effect = raise_
+    else:
+        m.get_export_from_serialized_record.return_value = return_
+    return m
+
+
+class TestRecordDictToLinksetMissingDatacite:
+    """record_dict_to_linkset must not crash when DataCite export is absent."""
+
+    def test_returns_empty_string_on_value_error(self):
+        """ValueError from missing export must produce an empty string, not HTTP 500."""
+        runtime = _mock_runtime(raise_=ValueError("No export found for mimetype"))
+        with patch(
+            "oarepo_runtime.resources.signposting.current_runtime",
+            new=runtime,
+        ):
+            result = record_dict_to_linkset({})
+        assert result == "", f"Expected '' got {result!r}"
+
+    def test_returns_empty_string_on_key_error(self):
+        runtime = _mock_runtime(raise_=KeyError("datacite"))
+        with patch(
+            "oarepo_runtime.resources.signposting.current_runtime",
+            new=runtime,
+        ):
+            result = record_dict_to_linkset({})
+        assert result == ""
+
+    def test_delegates_to_create_linkset_on_success(self):
+        """When export succeeds, the datacite dict must be forwarded to create_linkset."""
+        datacite_stub = {"titles": [{"title": "Test"}]}
+        runtime = _mock_runtime(return_=datacite_stub)
+        create_linkset_mock = MagicMock(return_value="link-header-value")
+        with (
+            patch(
+                "oarepo_runtime.resources.signposting.current_runtime",
+                new=runtime,
+            ),
+            patch(
+                "oarepo_runtime.resources.signposting.create_linkset",
+                new=create_linkset_mock,
+            ),
+        ):
+            result = record_dict_to_linkset({"links": {"self_html": "https://example.com"}})
+        create_linkset_mock.assert_called_once()
+        assert result == "link-header-value"
+
+
+class TestRecordDictToJsonLinksetMissingDatacite:
+    """record_dict_to_json_linkset must not crash when DataCite export is absent."""
+
+    def test_returns_empty_dict_on_value_error(self):
+        """ValueError from missing export must produce {}, not HTTP 500."""
+        runtime = _mock_runtime(raise_=ValueError("No export found for mimetype"))
+        with patch(
+            "oarepo_runtime.resources.signposting.current_runtime",
+            new=runtime,
+        ):
+            result = record_dict_to_json_linkset({})
+        assert result == {}
+
+    def test_returns_empty_dict_on_key_error(self):
+        runtime = _mock_runtime(raise_=KeyError("datacite"))
+        with patch(
+            "oarepo_runtime.resources.signposting.current_runtime",
+            new=runtime,
+        ):
+            result = record_dict_to_json_linkset({})
+        assert result == {}
+
+    def test_delegates_to_create_linkset_json_on_success(self):
+        datacite_stub = {"titles": [{"title": "Test"}]}
+        runtime = _mock_runtime(return_=datacite_stub)
+        create_linkset_json_mock = MagicMock(return_value={"linkset": []})
+        with (
+            patch(
+                "oarepo_runtime.resources.signposting.current_runtime",
+                new=runtime,
+            ),
+            patch(
+                "oarepo_runtime.resources.signposting.create_linkset_json",
+                new=create_linkset_json_mock,
+            ),
+        ):
+            result = record_dict_to_json_linkset({"links": {"self_html": "https://example.com"}})
+        create_linkset_json_mock.assert_called_once()
+        assert result == {"linkset": []}


### PR DESCRIPTION
`oarepo_ui`'s `response_header_signposting` decorator calls `record_dict_to_linkset`, which calls
`get_export_from_serialized_record(..., export_mimetype="application/vnd.datacite.datacite+json")`.
For record types that have no DataCite export configured, `get_export_from_serialized_record` raises
`ValueError`, which propagates through `record_dict_to_linkset` and causes an HTTP 500 on every
request to that record's detail page.

The decorator already guards against a falsy linkset result (`if record_linkset:`), so the correct
silent fallback is to return an empty string (or `{}` for the JSON variant) rather than letting the
exception propagate.